### PR TITLE
Merging tf-aws-minio-disks integration

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@ locals {
   }
   // Host names
   host_names = [for v in range(1, var.hosts+1): "${var.application_name}-${v}"]
-  
+
   // Disks
   disks = [
     "f",
@@ -33,4 +33,19 @@ locals {
     "y",
     "z"
   ]
+
+  disk_names = [ for d in toset(slice(local.disks, 0, var.num_disks)) : format("xvd%s", d) ]
+
+  ebs_volumes = flatten([
+    for host_key, host_info in aws_instance.minio_host : [
+      for disk in local.disk_names : {
+        id                 = host_info.id
+        availability_zone  = host_info.availability_zone
+        disk_name          = disk
+        unique_key         = format("%s__%s__%s", host_info.id, host_info.availability_zone, disk)
+      }
+    ]
+  ])
+
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,25 @@
+output "local-disks" {
+  value       = local.disks
+}
+
+output "disk-names" {
+  value       = local.disk_names
+}
+
+
+output "subnets" {
+  value     = var.subnets
+}
+
+output "ec2s" {
+  value   = aws_instance.minio_host
+}
+
+output "minio_host_info" {
+  value = {
+    for k, v in aws_instance.minio_host : k => {
+      id                 = v.id
+      availability_zone  = v.availability_zone
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,3 +23,7 @@ output "minio_host_info" {
     }
   }
 }
+
+output "ebs_storage_volume_size" {
+  value = var.ebs_storage_volume_size
+}

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "allow_bastion_to_ssh_minio_cluster" {
   source_security_group_id = aws_security_group.bastion_sg.id
 }
 
-resource "aws_security_group_rule" "allow_minio_api" {
+resource "aws_security_group_rule" "allow_minio_api_ingress" {
   type                     = "ingress"
   from_port                = var.minio_api_port
   to_port                  = var.minio_api_port
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "allow_minio_api" {
   cidr_blocks              = [ "0.0.0.0/0" ]
 }
 
-resource "aws_security_group_rule" "allow_minio_console" {
+resource "aws_security_group_rule" "allow_minio_console_ingress" {
   type                     = "ingress"
   from_port                = var.minio_console_port
   to_port                  = var.minio_console_port
@@ -142,22 +142,4 @@ resource "aws_security_group_rule" "allow_global_egress_bastion" {
     protocol                 = "-1"
     security_group_id        = aws_security_group.bastion_sg.id
     cidr_blocks              = [ "0.0.0.0/0" ]
-}
-
-resource "aws_security_group_rule" "allow_global_grafana_bastion_sg" {
-  type                     = "ingress"
-  from_port                = 3000
-  to_port                  = 3000
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.bastion_sg.id
-  cidr_blocks              = [ "0.0.0.0/0" ]
-}
-
-resource "aws_security_group_rule" "allow_global_prometheus_bastion_sg" {
-  type                     = "ingress"
-  from_port                = 9090
-  to_port                  = 9090
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.bastion_sg.id
-  cidr_blocks              = [ "0.0.0.0/0" ]
 }

--- a/setup.sh
+++ b/setup.sh
@@ -161,8 +161,8 @@ EOF
   done
 
   # Enable and start minio service
-  sudo systemctl enable minio
-  sudo systemctl start minio
+  # sudo systemctl enable minio
+  # sudo systemctl start minio
 }
 
 ############

--- a/setup.sh
+++ b/setup.sh
@@ -49,6 +49,7 @@ minio_installation() {
   disk_count=${disk_count}
   node_name=$(echo ${node_name} | sed 's|[0-9]||g')
   hosts=${hosts}
+  disks=${disks}
 
   # Setup Hostname
   sudo hostnamectl set-hostname ${node_name}
@@ -76,6 +77,20 @@ minio_installation() {
 
   # Create minio-user user
   sudo useradd -m -d /home/minio-user -r -g minio-user minio-user
+
+  # Until loop that waits for all xvd disks to be attached
+  echo "Starting for loop"
+  echo $disks
+  for disk in ${disks}; do
+    name=$(echo $disk | sed "s|\/| |g" | awk {'print $NF'})
+    while [[ $(lsblk | grep $name | wc -l) == "0" ]]; do
+      echo "$(date) - Disk $disk not found...waiting..."
+      sleep 5
+    done;
+    echo "$(date) - Found $disk"
+  done;
+  echo "For loop completed"
+
 
   # Establish Disks
   idx=1


### PR DESCRIPTION
After discovering that tf-aws-minio-cluster could not stage the creations of EBS volumes, prior to deploying EC2 instances, a secondary module called [tf-aws-minio-disks](https://github.com/excircle/tf-aws-minio-disks) was created to facilitate the creation of EBS volumes.

By splitting this into 2 modules, we are able to ensure that the creation of EBS volumes occurs and does so with respect to the values defined in the module definition of tf-aws-minio-cluster.